### PR TITLE
Add password fields to DeploymentName page object

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,35 @@ to define classes allowing access to each of the gui pages.
 ## API Testing
 
 These tests use fusor REST api to test QCI.
+
+## Using jupyter notebook
+
+jupyter notebook is fine way to develop tests and page objects.
+With it you can run an interactive python shell that is very 
+conducive to debugging code.
+
+Once you have jupyter and notebook installed, you will want to 
+go to the root of this source repo, and start it:
+
+    jupyter notebook
+
+Then start up a python2 notebook.   After doing this, the following code
+can be pasted into a cell, and will get you to the point of having logged 
+into QCI:   
+
+    url = 'https://10.8.196.250'
+    login = 'admin'
+    passwd = 'changeme'
+    from selenium import webdriver              
+    from selenium.webdriver.common.by import By 
+    import sys
+    sys.path.append(".")
+    driver = webdriver.Chrome()
+    driver.get(url)
+    from pages.login import LoginPage
+    loginPage = LoginPage(url, driver)
+    loginPage.login(login, passwd)
+
+Note you will need to change the url, login and passwd to match your 
+installation.
+

--- a/pages/wizard/satellite/deployment_name.py
+++ b/pages/wizard/satellite/deployment_name.py
@@ -8,6 +8,8 @@ class DeploymentName(Base):
     # locators
     _name_loc = (By.ID, 'deployment_new_sat_name')
     _description_loc = (By.ID, 'deployment_new_sat_desc')
+    _password_loc = (By.ID, 'common-password')
+    _confirm_password_loc = (By.ID, 'confirm-common-password')
 
     # properties
     @property
@@ -18,12 +20,26 @@ class DeploymentName(Base):
     def description(self):
         return self.selenium.find_element(*self._description_loc)
 
+    @property
+    def password(self):
+        return self.selenium.find_element(*self._password_loc)
+
+    @property
+    def confirm_password(self):
+        return self.selenium.find_element(*self._confirm_password_loc)
+
     # actions
     def set_name(self, name):
         self.name.send_keys(name)
 
     def set_description(self, description):
         self.description.send_keys(description)
+
+    def set_password(self, password):
+        self.password.send_keys(password)
+
+    def set_confirm_password(self, password):
+        self.confirm_password.send_keys(password)
 
     def click_back(self):
         from pages.wizard.product_selection import SelectProductsPage


### PR DESCRIPTION
Also added some text to the README.md about jupyter notebook.
Oh, yeah, the locators for name and description had been changed so I fixed that too.   Probably should have done that in different commit...bummer.