### PR TITLE
rename 'RHEV' to 'RHV'

### DIFF
--- a/pages/wizard/regions/deployment_step_bar.py
+++ b/pages/wizard/regions/deployment_step_bar.py
@@ -17,7 +17,7 @@ _step_to_page_map = {
             'library': 'pages.wizard.satellite.insights',
         },
     },
-    'RHEV': {
+    'RHV': {
         'first': {
             'class': 'SetupType',
             'library': 'pages.wizard.rhev.setup_type',


### PR DESCRIPTION
RHEV got renamed in deployment step bar to RHV, this quick fix is to reflex the change in automation.