### PR TITLE
Add rhv self-hosted

### DIFF
--- a/pages/wizard/regions/task_step_bar.py
+++ b/pages/wizard/regions/task_step_bar.py
@@ -36,6 +36,10 @@ _step_to_page_map = {
         'class': 'Hypervisor',
         'library': 'pages.wizard.rhev.hypervisor',
     },
+    'RHV.Engine/Hypervisor': {
+        'class': 'Hypervisor',
+        'library': 'pages.wizard.rhev.hypervisor',
+    },
     'RHV.Configuration': {
         'class': 'Configuration',
         'library': 'pages.wizard.rhev.configuration',


### PR DESCRIPTION
Since the hosts table is the same for pages 'Hypervisor' and self-hosted 'Engine/Hypervisor', I've just added a step to the task_step_bar, directing the page to use the 'Hypervisor' class.