### PR TITLE
Fix fusor_api call for adding an undercloud

### DIFF
--- a/lib/api/fusor_api.py
+++ b/lib/api/fusor_api.py
@@ -1105,7 +1105,7 @@ class OSPFusorApi(FusorDeploymentApi):
             "undercloud_user": ssh_user,
             "undercloud_password": ssh_pass, }
 
-        resource = "{}/undercloud".format(self.deployment_id)
+        resource = "{}/underclouds".format(self.deployment_id)
         response = self._openstack_post_resource(resource, undercloud_data)
 
         if response.status_code not in [200, 202]:


### PR DESCRIPTION
Restoring the 's' on the endpoint for adding an undercloud to a deployment using the fusor api