### PR TITLE
Use the RHN SMA uuid to select the SMA on the page

### DIFF
--- a/lib/deployment_runner.py
+++ b/lib/deployment_runner.py
@@ -141,7 +141,7 @@ class UIDeploymentRunner(object):
 
     def subscription_management(self, page):
         '''Subscription Management Application'''
-        page.click_sma_radio(self.sat.rhsm_satellite_name)
+        page.click_sma_radio_by_uuid(self.sat.rhsm_satellite['uuid'])
         return page.click_next()
 
     def add_subscriptions(self, page):

--- a/pages/wizard/subscriptions/subscription_management.py
+++ b/pages/wizard/subscriptions/subscription_management.py
@@ -44,6 +44,17 @@ class SubscriptionManagement(Base):
     def click_submit_new_sma(self):
         return self.new_sma_submit_button.click()
 
+    def click_sma_radio_by_uuid(self, uuid):
+        """ Click the radio button for the SMA with the specified uuid """
+        self.wait_for_ajax()
+        for sat in self.sma_radio_buttons:
+            if uuid in sat.get_attribute('value'):
+                # scroll to the element
+                self.scroll_to_element(sat)
+                return sat.click()
+        else:
+            raise Exception("No SMA found with uuid: {}".format(uuid))
+
     def click_sma_radio(self, name):
         """ Click the radio button for the SMA with the specified name """
         self.wait_for_ajax()

--- a/tests/api/test_api_osp_deployment.py
+++ b/tests/api/test_api_osp_deployment.py
@@ -147,7 +147,7 @@ def test_osp_api(osp_api, variables):
     cfme_root_password = dep_cfme['cfme_root_password']
     rhn_username = variables['credentials']['cdn']['username']
     rhn_password = variables['credentials']['cdn']['password']
-    rhn_sma_uuid = get_sma_uuid(osp_api, rhn_username, rhn_password, dep_sat['rhsm_satellite_name'])
+    rhn_sma_uuid = dep_sat['rhsm_satellite']['uuid']
     ose_sub_pool_name = dep_ose['subscription']['name']
     ose_sub_quantity = dep_ose['subscription']['quantity']
     osp_deploy_ramdisk_name = 'bm-deploy-ramdisk'

--- a/variables.yaml.example
+++ b/variables.yaml.example
@@ -67,7 +67,9 @@ deployment:
       disconnected_url: http://example.com
       enable_access_insights: false
       env_path: null
-      rhsm_satellite_name: sma_name # requires a valid SMA name
+      rhsm_satellite:
+        name: sma_name # requires a valid SMA name. QCI may mangle the sma name by changing '-' to '_'
+        uuid: sma_uuid # requires a valid SMA uuid
       rhsm_subs:
       - Red Hat Cloud Infrastructure with Smart Management
       sat_desc: description


### PR DESCRIPTION
QCI will mangle the SMA name used in the data-qci attribute by
converting '-' to '_'. It's better to use the uuid since that will
always have the same format and won't be changed

Update osp api test for using yaml uuid
