### PR TITLE
Rhev install review spinner wait

### DIFF
--- a/pages/wizard/review/installation_review.py
+++ b/pages/wizard/review/installation_review.py
@@ -18,9 +18,11 @@ class InstallationReview(Base):
                                  '//a[@data-qci="cfme_database_password"]/following-sibling::i')
     _deploy_button_loc = (By.XPATH,
                           '//button[text()="Deploy"]')
+    _build_task_spinner_locator = (
+        By.XPATH,
+        "//div[contains(@class, 'spinner-md') and contains(., 'Building task list']")
 
     # elements
-
     @property
     def rhev_root_pw_eye_icon(self):
         return self.selenium.find_element(*self._rhev_root_pw_eye_loc)
@@ -45,6 +47,10 @@ class InstallationReview(Base):
     def deploy_button(self):
         return self.selenium.find_element(*self._deploy_button_loc)
 
+    @property
+    def building_task_spinner(self):
+        return self.selenium.find_element(*self._build_task_spinner_locator)
+
     # actions
 
     def reveal_rhev_root_pw(self):
@@ -65,5 +71,6 @@ class InstallationReview(Base):
     def click_deploy(self):
         from pages.wizard.review.installation_progress import InstallationProgress
         self.wait_for_ajax()
+        self.wait_until_element_is_not_visible(*self._build_task_spinner_locator)
         self.deploy_button.click()
         return InstallationProgress(self.base_url, self.selenium)

--- a/pages/wizard/review/installation_review.py
+++ b/pages/wizard/review/installation_review.py
@@ -71,6 +71,6 @@ class InstallationReview(Base):
     def click_deploy(self):
         from pages.wizard.review.installation_progress import InstallationProgress
         self.wait_for_ajax()
-        self.wait_until_element_is_not_visible(*self._build_task_spinner_locator)
         self.deploy_button.click()
+        self.wait_until_element_is_not_visible(self._build_task_spinner_locator)
         return InstallationProgress(self.base_url, self.selenium)


### PR DESCRIPTION
Whenever the deploy button is clicked on the installation review page there is a spinner element for "Building task list..." before navigation to installation progress.  This just adds a wait for that spinner element before returning an installation progress page object