### PR TITLE
Minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Python Virtual Environments
+*.virtenv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python Virtual Environments
 *.virtenv
+*.venv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ this repository.
 * setup.cfg 
 * variables.json.example - contains data needed by the tests.
 
+# Updating Python Requirements
+
+If you want to just update the python libraries on your box, then become
+root, go to the root of this source tree, and run the command:
+
+    pip install -r requirements.txt
+
+If however you want use a python virtual environment (see 
+https://virtualenv.pypa.io/en/stable/) then you can use this set 
+of commands:
+
+    virtualenv ${workspace}.venv
+    . ${workspace}.venv/bin/activate
+    pip install -r requirements.txt
+
+Note, git is configured to ignore files that end in `.venv` and
+`.virtenv`, so though adding one of these extensions is not required
+it will make it so the virtual environment does not pollute your
+`git status` calls.
+
+A really good guide to learning about virtual environments is:
+
+    http://docs.python-guide.org/en/latest/dev/virtualenvs/
+
 # Testing
 
 Presently testing is broken down into:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ A really good guide to learning about virtual environments is:
 
     http://docs.python-guide.org/en/latest/dev/virtualenvs/
 
+# Checking source against pep8 standard
+
+You can use the flake8 program to verify that source adheres to the
+pep8 standard.  To do so with the configuration for this repo run:
+
+    flake8 --config=setup.cfg $src
+
+or:
+
+    flake8 --config=setup.cfg $srcDir
+
+
 # Testing
 
 Presently testing is broken down into:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ this repository.
 * pytest.ini.example - example config for pytest.
 * README.md - this file.
 * requirements.txt - python libraries needed by this repository.
-* setup.cfg 
+* setup.cfg - flake8 config.
 * variables.json.example - contains data needed by the tests.
 
 # Updating Python Requirements
@@ -48,10 +48,10 @@ of commands:
     . ${workspace}.venv/bin/activate
     pip install -r requirements.txt
 
-Note, git is configured to ignore files that end in `.venv` and
-`.virtenv`, so though adding one of these extensions is not required
-it will make it so the virtual environment does not pollute your
-`git status` calls.
+Note, git is configured in this repository to ignore files that end 
+in `.venv` and `.virtenv`, so though adding one of these extensions 
+is not required it will make it so the virtual environment does not
+pollute your `git status` calls.
 
 A really good guide to learning about virtual environments is:
 

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -1,5 +1,3 @@
-from selenium.webdriver.common.by import By
-
 from pages.base import Base
 
 

--- a/pages/regions/header_menu.py
+++ b/pages/regions/header_menu.py
@@ -41,8 +41,12 @@ class HeaderMenu(Page):
         for menu in self.items:
             if menu.name == value:
                 return menu
-        raise Exception("Menu not found: '%s'. Menus: %s" % (
-                value, [menu.name for menu in self.items]))
+        raise Exception(
+            "Menu not found: '%s'. Menus: %s" % (
+                value,
+                [menu.name for menu in self.items]
+            )
+        )
 
     @property
     def items(self):

--- a/pages/wizard/cloudforms/configuration.py
+++ b/pages/wizard/cloudforms/configuration.py
@@ -1,7 +1,6 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 class Configuration(Base):
     _page_title = "Configuration"

--- a/pages/wizard/cloudforms/installation_location.py
+++ b/pages/wizard/cloudforms/installation_location.py
@@ -1,7 +1,6 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 class InstallationLocation(Base):
     _page_title = "Installation Location"

--- a/pages/wizard/openshift/configuration.py
+++ b/pages/wizard/openshift/configuration.py
@@ -1,6 +1,7 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
+
 class Configuration(Base):
     _page_title = "QuickStart Cloud Installer"
     _nfs_radio_loc = (By.XPATH, "//input[@value='NFS']")
@@ -85,4 +86,3 @@ class Configuration(Base):
 
     def click_hello_world(self):
         self.hello_world_checkbox.click()
-

--- a/pages/wizard/openshift/nodes.py
+++ b/pages/wizard/openshift/nodes.py
@@ -1,6 +1,7 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
+
 class Nodes(Base):
     _page_title = "QuickStart Cloud Installer"
     _rhv_radio_loc = (By.XPATH, "//input[@value='RHEV']")
@@ -121,4 +122,3 @@ class Nodes(Base):
     def set_worker_disk(self, number):
         self.worker_disk.clear()
         self.worker_disk.send_keys(number)
-

--- a/pages/wizard/openstack/assign_nodes.py
+++ b/pages/wizard/openstack/assign_nodes.py
@@ -10,7 +10,6 @@ from selenium.webdriver.support.select import Select
 from selenium.webdriver.common.action_chains import ActionChains
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 # Huge map of Global Config input field names to their type.
 # Their type can be either "text" or "checkbox".   Number types
@@ -257,23 +256,28 @@ role_to_box_name = {
     'object-storage': 'Object Storage',
 }
 
+
 class GlobalConfItemUndefinedError(Exception):
     def __init__(self, name):
         self.name = name
+
     def __str__(self):
         return "Undefined global config item: {}".format(self.name)
+
 
 class GlobalConfItemTypeError(Exception):
     def __init__(self, name, needed_type, cur_type):
         self.name = name
         self.needed_type = needed_type
         self.cur_type = cur_type
+
     def __str__(self):
         return "Global config item {} needed type {} provided type {}".format(
             self.name,
             self.needed_type,
             self.cur_type,
         )
+
 
 class AssignNodes(Base):
     _page_title = "QuickStart Cloud Installer"
@@ -455,10 +459,10 @@ class AssignNodes(Base):
 
     def get_assigned_role_node_count_options(self, role):
         selector = self.get_selector_assigned_role_node_count(role)
-        nodeChoices = []
+        node_choices = []
         for option in selector.options():
-            nodeChoices.append(options.get_attribute('value'))
-        return nodeChoices
+            node_choices.append(option.get_attribute('value'))
+        return node_choices
 
     def hover_assigned_role(self, role):
         locator_type = self._assigned_role_template_loc[0]
@@ -497,10 +501,10 @@ class AssignNodes(Base):
     #       combination.   At this point the locators are set the way
     #       development suggested.
     def assign_role_by_drag(self, role):
-        roleBoxSource = self.get_role_box(role)
-        assignRoleTarget = self.assign_role_draggable_target
+        role_box_source = self.get_role_box(role)
+        assign_role_target = self.assign_role_draggable_target
         actions = ActionChains(self.selenium)
-        actions.drag_and_drop(roleBoxSource, assignRoleTarget).perform()
+        actions.drag_and_drop(role_box_source, assign_role_target).perform()
 
     #
     # <<< Edit Global Config >>>
@@ -519,7 +523,7 @@ class AssignNodes(Base):
         element = self.global_config_element(name)
         if global_config_to_type_map[name] == 'checkbox':
             raise GlobalConfItemTypeError(
-                name==name,
+                name=name,
                 needed_type='text',
                 cur_type='checkbox',
             )

--- a/pages/wizard/openstack/configure_overcloud.py
+++ b/pages/wizard/openstack/configure_overcloud.py
@@ -9,7 +9,6 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 class ConfigureOvercloud(Base):
     _page_title = "QuickStart Cloud Installer"
@@ -156,4 +155,3 @@ class ConfigureOvercloud(Base):
     def set_glance_rbd_pool_name(self, text):
         self.glance_rbd_pool_name.clear()
         self.glance_rbd_pool_name.send_keys(text)
-

--- a/pages/wizard/openstack/detect_undercloud.py
+++ b/pages/wizard/openstack/detect_undercloud.py
@@ -1,7 +1,6 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 class DetectUndercloud(Base):
     _page_title = "QuickStart Cloud Installer"

--- a/pages/wizard/openstack/register_nodes.py
+++ b/pages/wizard/openstack/register_nodes.py
@@ -32,7 +32,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 class RegisterNodes(Base):
     _page_title = "QuickStart Cloud Installer"
@@ -166,7 +165,7 @@ class RegisterNodes(Base):
     # <<< Node Auto Detection >>>
     @property
     def rescan(self):
-        return  self.selenium.find_element(*self._rescan_loc)
+        return self.selenium.find_element(*self._rescan_loc)
 
     @property
     def node_list_rows(self):
@@ -270,7 +269,7 @@ class RegisterNodes(Base):
         selector = self.node_list_row_get_interface_select(row_id)
         macs = []
         for option in selector.options:
-           macs.append(option.get_attribute('value'))
+            macs.append(option.get_attribute('value'))
         return macs
 
     def node_list_row_select_interface(self, row_id, mac):

--- a/pages/wizard/regions/deployment_step_bar.py
+++ b/pages/wizard/regions/deployment_step_bar.py
@@ -103,65 +103,65 @@ class DeploymentStepBar():
 
     ABBREVIATIONS:
 
-        DSB - Deployment Step Bar
+        dsb - Deployment Step Bar
     """
     def __init__(self, base_url, selenium):
         self.base_url = base_url
         self.selenium = selenium
 
     # locators:
-    _DSB_loc = (By.XPATH, '//ul[@class="rhci-steps"]')
-    _DSB_steps_loc = (By.XPATH, "{}/li".format(_DSB_loc[1]))
-    _DSB_active_step_loc = (
+    _dsb_loc = (By.XPATH, '//ul[@class="rhci-steps"]')
+    _dsb_steps_loc = (By.XPATH, "{}/li".format(_dsb_loc[1]))
+    _dsb_active_step_loc = (
         By.XPATH,
-        '{}[contains(@class, "active")]'.format(_DSB_steps_loc[1])
+        '{}[contains(@class, "active")]'.format(_dsb_steps_loc[1])
     )
-    _DSB_after_active_step_loc = (
+    _dsb_after_active_step_loc = (
         By.XPATH,
-        '{}/following-sibling::li[1]'.format(_DSB_active_step_loc[1]),
+        '{}/following-sibling::li[1]'.format(_dsb_active_step_loc[1]),
     )
-    _DSB_before_active_step_loc = (
+    _dsb_before_active_step_loc = (
         By.XPATH,
-        '{}/preceding-sibling::li[1]'.format(_DSB_active_step_loc[1]),
+        '{}/preceding-sibling::li[1]'.format(_dsb_active_step_loc[1]),
     )
 
     # properties
     @property
-    def DSB(self):
-        return self.selenium.find_element(*self._DSB_loc)
+    def dsb(self):
+        return self.selenium.find_element(*self._dsb_loc)
 
     @property
-    def DSB_steps(self):
-        return self.selenium.find_elements(*self._DSB_steps_loc)
+    def dsb_steps(self):
+        return self.selenium.find_elements(*self._dsb_steps_loc)
 
     @property
-    def DSB_active_step(self):
-        return self.selenium.find_element(*self._DSB_active_step_loc)
+    def dsb_active_step(self):
+        return self.selenium.find_element(*self._dsb_active_step_loc)
 
     @property
-    def DSB_after_active_step(self):
-        return self.selenium.find_element(*self._DSB_after_active_step_loc)
+    def dsb_after_active_step(self):
+        return self.selenium.find_element(*self._dsb_after_active_step_loc)
 
     @property
-    def DSB_before_active_step(self):
-        return self.selenium.find_element(*self._DSB_before_active_step_loc)
+    def dsb_before_active_step(self):
+        return self.selenium.find_element(*self._dsb_before_active_step_loc)
 
     def number_of_steps(self):
-        steps = self.DSB_steps
+        steps = self.dsb_steps
         return len(steps)
 
     def get_name_of_step(self, step):
         return re.sub('^\d+\.\s+', '', step.text)
 
     def get_step_by_number(self, index):
-        steps = self.DSB_steps
+        steps = self.dsb_steps
         return steps[index - 1]
 
     def get_next_step(self):
-        return self.DSB_after_active_step
+        return self.dsb_after_active_step
 
     def get_prev_step(self):
-        return self.DSB_before_active_step
+        return self.dsb_before_active_step
 
     def get_page(self, direction='NEXT'):
         """

--- a/pages/wizard/regions/navigation_buttons.py
+++ b/pages/wizard/regions/navigation_buttons.py
@@ -1,6 +1,6 @@
-import re
 from selenium.webdriver.common.by import By
 from pages.wizard.regions.task_step_bar import TaskStepBar
+
 
 class NavigationButtons():
     """
@@ -90,18 +90,18 @@ class NavigationButtons():
         # before we actually click the navigation
         # button, so that when determining where to go we start
         # from where we are:
-        prevPage = self.task_step_bar.get_prev_page()
+        prev_page = self.task_step_bar.get_prev_page()
         self.back_btn.click()
-        return prevPage
+        return prev_page
 
     def click_next(self):
         # It's important that we get the next page
         # before we actually click the navigation
         # button, so that when determining where to go we start
         # from where we are:
-        nextPage = self.task_step_bar.get_next_page()
+        next_page = self.task_step_bar.get_next_page()
         self.next_btn.click()
-        return nextPage
+        return next_page
 
     # Note a modal frame will open when this is clicked, with the
     # buttons:

--- a/pages/wizard/regions/task_step_bar.py
+++ b/pages/wizard/regions/task_step_bar.py
@@ -127,8 +127,8 @@ class TaskStepBar():
 
     ABBREVIATIONS:
 
-        TSB - Task Step Bar
-        DSB - Deployment Step Bar
+        tsb - Task Step Bar
+        dsb - Deployment Step Bar
     """
     def __init__(self, base_url, selenium):
         self.base_url = base_url
@@ -139,44 +139,44 @@ class TaskStepBar():
         )
 
     # locators:
-    _TSB_loc = (By.XPATH, '//ul[contains(@class, "nav-stacked")]')
-    _TSB_steps_loc = (By.XPATH, "{}/li".format(_TSB_loc[1]))
-    _TSB_active_step_loc = (
+    _tsb_loc = (By.XPATH, '//ul[contains(@class, "nav-stacked")]')
+    _tsb_steps_loc = (By.XPATH, "{}/li".format(_tsb_loc[1]))
+    _tsb_active_step_loc = (
         By.XPATH,
-        '{}[contains(@class, "active")]'.format(_TSB_steps_loc[1])
+        '{}[contains(@class, "active")]'.format(_tsb_steps_loc[1])
     )
-    _TSB_after_active_step_loc = (
+    _tsb_after_active_step_loc = (
         By.XPATH,
-        '{}/following-sibling::li[1]'.format(_TSB_active_step_loc[1]),
+        '{}/following-sibling::li[1]'.format(_tsb_active_step_loc[1]),
     )
-    _TSB_before_active_step_loc = (
+    _tsb_before_active_step_loc = (
         By.XPATH,
-        '{}/preceding-sibling::li[1]'.format(_TSB_active_step_loc[1]),
+        '{}/preceding-sibling::li[1]'.format(_tsb_active_step_loc[1]),
     )
 
     # properties
     @property
-    def TSB(self):
-        return self.selenium.find_element(*self._TSB_loc)
+    def tsb(self):
+        return self.selenium.find_element(*self._tsb_loc)
 
     @property
-    def TSB_steps(self):
-        return self.selenium.find_elements(*self._TSB_steps_loc)
+    def tsb_steps(self):
+        return self.selenium.find_elements(*self._tsb_steps_loc)
 
     @property
-    def TSB_active_step(self):
-        return self.selenium.find_element(*self._TSB_active_step_loc)
+    def tsb_active_step(self):
+        return self.selenium.find_element(*self._tsb_active_step_loc)
 
     @property
-    def TSB_after_active_step(self):
-        return self.selenium.find_element(*self._TSB_after_active_step_loc)
+    def tsb_after_active_step(self):
+        return self.selenium.find_element(*self._tsb_after_active_step_loc)
 
     @property
-    def TSB_before_active_step(self):
-        return self.selenium.find_element(*self._TSB_before_active_step_loc)
+    def tsb_before_active_step(self):
+        return self.selenium.find_element(*self._tsb_before_active_step_loc)
 
     def number_of_steps(self):
-        steps = self.TSB_steps
+        steps = self.tsb_steps
         return len(steps)
 
     def get_name_of_step(self, step):
@@ -197,31 +197,31 @@ class TaskStepBar():
         return re.sub(r'^\d+[A-Z]\.\s+', '', step.text)
 
     def get_number_of_step(self, step):
-        alphaIndex = re.sub(r'^\d+([A-Z])\.\s+.*', r'\1', step.text)
-        numberIndex = ord(alphaIndex) - ord('A') + 1
-        return numberIndex
+        alpha_index = re.sub(r'^\d+([A-Z])\.\s+.*', r'\1', step.text)
+        number_index = ord(alpha_index) - ord('A') + 1
+        return number_index
 
     def get_step_by_number(self, index):
-        steps = self.TSB_steps
+        steps = self.tsb_steps
         return steps[index - 1]
 
     def get_current_step(self):
-        return self.TSB_active_step
+        return self.tsb_active_step
 
     def get_next_step(self):
-        active_step = self.TSB_active_step
+        active_step = self.tsb_active_step
         number_of_step = self.get_number_of_step(active_step)
         number_of_steps = self.number_of_steps()
         if number_of_step == number_of_steps:
             return None
-        return self.TSB_after_active_step
+        return self.tsb_after_active_step
 
     def get_prev_step(self):
-        active_step = self.TSB_active_step
+        active_step = self.tsb_active_step
         number_of_step = self.get_number_of_step(active_step)
         if number_of_step == 1:
             return None
-        return self.TSB_before_active_step
+        return self.tsb_before_active_step
 
     def get_page(self, direction='NEXT'):
         """
@@ -245,9 +245,8 @@ class TaskStepBar():
 
         # If we would navigate past the current list of tasks
         # then we need to your the DeploymentStepBar navigator:
-        if step == None:
+        if step is None:
             return self.deployment_step_bar.get_page(direction)
-
 
         # We are within our list, so let's continue on.
         #
@@ -257,7 +256,7 @@ class TaskStepBar():
         # task step name to do our lookup.
         step_name = self.get_name_of_step(step)
         deployment_step_name = self.deployment_step_bar.get_name_of_step(
-            self.deployment_step_bar.DSB_active_step
+            self.deployment_step_bar.dsb_active_step
         )
         fully_qualified_step_name = "{}.{}".format(
             deployment_step_name,

--- a/pages/wizard/rhv/configuration.py
+++ b/pages/wizard/rhv/configuration.py
@@ -1,6 +1,7 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
+
 class Configuration(Base):
     _page_title = "QuickStart Cloud Installer"
     _root_password_loc = (By.ID, "rhev-root-password")
@@ -101,4 +102,3 @@ class Configuration(Base):
             except StaleElementReferenceException:
                 pass
         raise NameError("Can't find specified cpu type.")
-

--- a/pages/wizard/rhv/engine.py
+++ b/pages/wizard/rhv/engine.py
@@ -2,6 +2,7 @@ from selenium.webdriver.common.by import By
 from pages.base import Base
 from pages.wizard.rhv.hosts import Hosts
 
+
 class Engine(Base):
     _page_title = "QuickStart Cloud Installer"
     _search_box_loc = (By.XPATH, "//div[@class = 'rhev-search-box']/input[@type = 'text']")
@@ -26,4 +27,3 @@ class Engine(Base):
 
     def click_refresh_data(self):
         self.refresh_data_button.click()
-

--- a/pages/wizard/rhv/hosts.py
+++ b/pages/wizard/rhv/hosts.py
@@ -1,4 +1,4 @@
-#allows operations with multiple hosts for RHV Engine and Hypervisor pages
+# allows operations with multiple hosts for RHV Engine and Hypervisor pages
 class Hosts():
 
     def __init__(self, table):
@@ -7,25 +7,25 @@ class Hosts():
         self.table = table
 
     def _make_host_objects(self, table):
-        return [self.Host(tr) for tr in \
-            table.find_element_by_tag_name('tbody').\
-            find_elements_by_tag_name('tr')]
+        return [
+            self.Host(tr) for tr in table.find_element_by_tag_name('tbody').find_elements_by_tag_name('tr')
+        ]
 
     def _make_heads(self, table):
-        return [head for head in \
-            table.find_element_by_tag_name('thead').\
-            find_elements_by_tag_name('th')]
+        return [
+            head for head in table.find_element_by_tag_name('thead').find_elements_by_tag_name('th')
+        ]
 
     def _get_host_with_attribute(self, attr, is_max):
         dct = {}
         for host in self.hosts:
-            dct.update({host:host.get_attr(attr)})
+            dct.update({host: host.get_attr(attr)})
         if is_max:
             return max(dct, key=dct.get)
         else:
             return min(dct, key=dct.get)
 
-    #Methods for choosing single host with minimum or maximum value of an attribute
+    # Methods for choosing single host with minimum or maximum value of an attribute
     def get_host_max_cpu(self):
         return self._get_host_with_attribute('cpu', True)
 
@@ -44,8 +44,8 @@ class Hosts():
     def get_host_min_disk_space(self):
         return self._get_host_with_attribute('space', False)
 
-    #Methods for choosing host by attribute
-    #First host that matches the attribute is returned
+    # Methods for choosing host by attribute
+    # First host that matches the attribute is returned
     def get_host_by_name(self, name):
         sname = str(name)
         for host in self.hosts:
@@ -109,7 +109,7 @@ class Hosts():
             if text == attr:
                 head.click()
 
-    #Methods for choosing host by the position in the table
+    # Methods for choosing host by the position in the table
     def get_first_host(self):
         new_hosts = self._make_host_objects(self.table)
         return new_hosts[0]
@@ -118,7 +118,7 @@ class Hosts():
         new_hosts = self._make_host_objects(self.table)
         return new_hosts[-1]
 
-    #Methods for sorting hosts in the table by attribute
+    # Methods for sorting hosts in the table by attribute
     def sort_hosts_by_name(self):
         self._sort_hosts_by_attribute("Host Name")
 
@@ -143,19 +143,19 @@ class Hosts():
     def sort_hosts_by_network(self):
         self._sort_hosts_by_attribute("Network")
 
-    #Represents a single host
+    # Represents a single host
     class Host():
 
         def __init__(self, table_row):
-            #data[0] - checkbox
-            #data[1] - host name
-            #data[2] - MAC address
-            #data[3] - host type
-            #data[4] - CPU
-            #data[5] - memory
-            #data[6] - disks
-            #data[7] - disk space
-            #data[8] - network
+            # data[0] - checkbox
+            # data[1] - host name
+            # data[2] - MAC address
+            # data[3] - host type
+            # data[4] - CPU
+            # data[5] - memory
+            # data[6] - disks
+            # data[7] - disk space
+            # data[8] - network
             self.data = table_row.find_elements_by_tag_name('td')
 
         def get_attr(self, attr):
@@ -179,8 +179,9 @@ class Hosts():
             return str(self.data[2].text)
 
         def htype(self):
-            return str(self.data[3].find_element_by_tag_name('span').\
-                get_attribute('data-original-title'))
+            return str(
+                self.data[3].find_element_by_tag_name('span').get_attribute('data-original-title')
+            )
 
         def cpu(self):
             return int(filter(str.isdigit, str(self.data[4].text)))
@@ -198,14 +199,13 @@ class Hosts():
             return str(self.data[8].text)
 
         def set_name(self, name):
-            #name can be set only to choosen hypervisor
+            # name can be set only to choosen hypervisor
             self.choose()
             sname = str(name)
             name_field = self.data[1].find_element_by_tag_name('input')
             name_field.clear()
-            #this is here because the name field looses focus when hypervisors are sorted
-            #sorting is automatic as user writes the name
+            # this is here because the name field looses focus when hypervisors are sorted
+            # sorting is automatic as user writes the name
             for c in sname:
                 name_field.send_keys(c)
                 name_field.click()
-

--- a/pages/wizard/rhv/hypervisor.py
+++ b/pages/wizard/rhv/hypervisor.py
@@ -2,6 +2,7 @@ from selenium.webdriver.common.by import By
 from pages.base import Base
 from pages.wizard.rhv.hosts import Hosts
 
+
 class Hypervisor(Base):
     _page_title = "QuickStart Cloud Installer"
     _search_box_loc = (By.XPATH, "//input[@placeholder=' Search ...']")
@@ -9,26 +10,40 @@ class Hypervisor(Base):
     _naming_scheme_loc = (By.XPATH, "//button[contains(.,'Edit Naming Scheme')]")
     _select_all_loc = (By.XPATH, "//span[@class = 'rhev-select-all']/a")
     _host_table_loc = (By.XPATH, "//div[@class = 'col-lg-9']/table")
-    _naming_scheme_cancel_loc = (By.XPATH, \
-        "//div[@class = 'modal-footer']/button[contains(., 'Cancel')]")
-    _naming_scheme_edit_loc = (By.XPATH, \
-        "//div[@class = 'modal-footer']/button[contains(., 'Edit')]")
+    _naming_scheme_cancel_loc = (
+        By.XPATH,
+        "//div[@class = 'modal-footer']/button[contains(., 'Cancel')]"
+    )
+    _naming_scheme_edit_loc = (
+        By.XPATH,
+        "//div[@class = 'modal-footer']/button[contains(., 'Edit')]"
+    )
     _naming_scheme_dropdown_loc = (By.XPATH, "//div[@role = 'button']")
-    _naming_scheme_dropwown_search_loc = (By.XPATH, \
-        "//div[@class = 'ember-power-select-search']/input")
-    _naming_scheme_dropwown_free_loc = (By.XPATH, \
-        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'Freeform')]")
-    _naming_scheme_dropwown_mac_loc = (By.XPATH, \
-        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'MAC address')]")
-    _naming_scheme_dropwown_hyper_loc = (By.XPATH, \
-        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'hypervisorN')]")
-    _naming_scheme_dropwown_custom_loc = (By.XPATH, \
-        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'Custom scheme')]")
+    _naming_scheme_dropwown_search_loc = (
+        By.XPATH,
+        "//div[@class = 'ember-power-select-search']/input"
+    )
+    _naming_scheme_dropwown_free_loc = (
+        By.XPATH,
+        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'Freeform')]"
+    )
+    _naming_scheme_dropwown_mac_loc = (
+        By.XPATH,
+        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'MAC address')]"
+    )
+    _naming_scheme_dropwown_hyper_loc = (
+        By.XPATH,
+        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'hypervisorN')]"
+    )
+    _naming_scheme_dropwown_custom_loc = (
+        By.XPATH,
+        "//div[@class = 'ember-power-select-search']/../ul/li[contains(., 'Custom scheme')]"
+    )
     _naming_scheme_custom_prepend_loc = (By.XPATH, "//div[@class = 'form-group ']/div/input")
-    #only for self-hosted
+    # only for self-hosted
     _engine_hostname_loc = (By.ID, "rhev-engine-hostname")
 
-    #only for self-hosted
+    # only for self-hosted
     @property
     def engine_hostname_field(self):
         return self.selenium.find_element(*self._engine_hostname_loc)
@@ -89,7 +104,7 @@ class Hypervisor(Base):
     def naming_scheme_custom_prepend_field(self):
         return self.selenium.find_element(*self._naming_scheme_custom_prepend_loc)
 
-    #only for self-hosted
+    # only for self-hosted
     def set_engine_hostname(self, hostname):
         self.engine_hostname_field.clear()
         self.engine_hostname_field.send_keys(hostname)
@@ -135,4 +150,3 @@ class Hypervisor(Base):
 
     def choose_naming_scheme_dropdown(self):
         self.naming_scheme_dropdown.click()
-

--- a/pages/wizard/rhv/setup_type.py
+++ b/pages/wizard/rhv/setup_type.py
@@ -1,7 +1,6 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 class SetupType(Base):
     _page_title = "Setup Type"

--- a/pages/wizard/rhv/storage.py
+++ b/pages/wizard/rhv/storage.py
@@ -1,6 +1,7 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
+
 class Storage(Base):
     _page_title = "QuickStart Cloud Installer"
     _nfs_radio_loc = (By.XPATH, "//input[@value='NFS']")
@@ -11,7 +12,7 @@ class Storage(Base):
     _export_domain_name_loc = (By.ID, "rhev_export_domain_name")
     _export_storage_address_loc = (By.ID, "rhev_export_domain_address")
     _export_share_path_loc = (By.ID, "rhev_export_domain_path")
-    #only for self-hosted
+    # only for self-hosted
     _hosted_domain_name_loc = (By.ID, "hosted_storage_name")
     _hosted_storage_address_loc = (By.ID, "hosted_storage_address")
     _hosted_share_path_loc = (By.ID, "hosted_storage_path")
@@ -48,17 +49,17 @@ class Storage(Base):
     def export_share_path_field(self):
         return self.selenium.find_element(*self._export_share_path_loc)
 
-    #only for self-hosted
+    # only for self-hosted
     @property
     def hosted_domain_name_field(self):
         return self.selenium.find_element(*self._hosted_domain_name_loc)
 
-    #only for self-hosted
+    #        only for self-hosted
     @property
     def hosted_storage_address_field(self):
         return self.selenium.find_element(*self._hosted_storage_address_loc)
 
-    #only for self-hosted
+    # only for self-hosted
     @property
     def hosted_share_path_field(self):
         return self.selenium.find_element(*self._hosted_share_path_loc)
@@ -104,4 +105,3 @@ class Storage(Base):
     def set_hosted_share_path(self, data):
         self.hosted_share_path_field.clear()
         self.hosted_share_path_field.send_keys(data)
-

--- a/pages/wizard/satellite/insights.py
+++ b/pages/wizard/satellite/insights.py
@@ -1,13 +1,13 @@
 from selenium.webdriver.common.by import By
 from pages.base import Base
 
-from pages.wizard.regions.deployment_step_bar import DeploymentStepBar
 
 class Insights(Base):
     _page_title = "Insights"
 
     # locators
     _enable_loc = (By.NAME, 'enable_access_insights')
+
     # properties
     @property
     def enable(self):

--- a/pages/wizard/satellite/update_availability.py
+++ b/pages/wizard/satellite/update_availability.py
@@ -25,7 +25,6 @@ class UpdateAvailability(Base):
         '//button[contains(.,"New Environment Path")]'
     )
 
-
     # properties
     @property
     def immediately(self):

--- a/pages/wizard/subscriptions/review_subscriptions.py
+++ b/pages/wizard/subscriptions/review_subscriptions.py
@@ -1,4 +1,3 @@
-from selenium.webdriver.common.by import By
 from pages.base import Base
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-flake8
-
 # Documentation requirements
 Sphinx
 sphinx-autobuild
@@ -9,3 +7,8 @@ sphinx_rtd_theme
 pytest
 pytest-selenium
 pytest-variables[yaml]
+
+# Code Lint Tools
+flake8
+pylint
+pep8-naming

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [flake8]
-ignore=E501
+# Ignore:
+#
+#   N812 - We like doing EC for the expected_conditions, even 
+#          though pep8 frowns on this.
+ignore=E501,N812

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,13 @@
 # Ignore:
 #
 #   N812 - We like doing EC for the expected_conditions, even 
-#          though pep8 frowns on this.
+#          though pep8 frowns on this, as it makes the code more
+#          compact and follows the examples found in the selenium
+#          docs:
+# 
+#               http://selenium-python.readthedocs.io/waits.html
+#   
+#   E501 - Though we don't want lines to be too long, sometimes they need
+#          to be longer than 79 characters, and so we are punting on this
+#          part of pep8.
 ignore=E501,N812

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # Ignore:
 #
-#   N812 - We like doing EC for the expected_conditions, even 
+#   N812 - We like doing EC for the expected_conditions, even
 #          though pep8 frowns on this, as it makes the code more
 #          compact and follows the examples found in the selenium
 #          docs:


### PR DESCRIPTION
Updated README.md with:

- information on using requirements.txt
- information on using virtual environments
- information on using flake8

Configured .gitignore to ignore files that end in .venv or .virtenv to provide a way to ignore
virtual environment directories in the source tree.

Made the page object code conform to flake8.   Here is a report of the flake8 warnings that I made changes for:

    pages/dashboard.py:1:1: F401 'selenium.webdriver.common.by.By' imported but unused
    pages/deployments.py:3:1: N812 lowercase imported as non lowercase
    pages/page.py:10:1: N812 lowercase imported as non lowercase
    pages/wizard/product_selection.py:3:1: N812 lowercase imported as non lowercase
    pages/wizard/cloudforms/configuration.py:4:1: F401     'pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/cloudforms/configuration.py:6:1: E302 expected 2 blank lines, found 1
    pages/wizard/cloudforms/installation_location.py:4:1: F401 'pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/cloudforms/installation_location.py:6:1: E302 expected 2 blank lines, found 1
    pages/wizard/openstack/register_nodes.py:35:1: F401 'pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/openstack/register_nodes.py:37:1: E302 expected 2 blank lines, found 1
    pages/wizard/openstack/register_nodes.py:169:15: E271 multiple spaces after keyword
    pages/wizard/openstack/register_nodes.py:273:12: E111 indentation is not a multiple of four
    pages/wizard/openstack/assign_nodes.py:13:1: F401 ' pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/openstack/assign_nodes.py:260:1: E302 expected 2 blank lines, found 1
    pages/wizard/openstack/assign_nodes.py:263:5: E301 expected 1 blank line, found 0
    pages/wizard/openstack/assign_nodes.py:266:1: E302 expected 2 blank lines, found 1
    pages/wizard/openstack/assign_nodes.py:271:5: E301 expected 1 blank line, found 0
    pages/wizard/openstack/assign_nodes.py:278:1: E302 expected 2 blank lines, found 1
    pages/wizard/openstack/assign_nodes.py:458:9: N806 variable in function should be lowercase
    pages/wizard/openstack/assign_nodes.py:460:32: F821 undefined name 'options'
    pages/wizard/openstack/assign_nodes.py:500:9: N806 variable in function should be lowercase
    pages/wizard/openstack/assign_nodes.py:501:9: N806 variable in function should be lowercase
    pages/wizard/openstack/assign_nodes.py:522:21: E225 missing whitespace around operator
    pages/wizard/openstack/configure_overcloud.py:12:1: F401 'pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/openstack/configure_overcloud.py:14:1: E302 expected 2 blank lines, found 1
    pages/wizard/openstack/configure_overcloud.py:159:1: W391 blank line at end of file
    pages/wizard/openstack/detect_undercloud.py:4:1: F401 'pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/openstack/detect_undercloud.py:6:1: E302 expected 2 blank lines, found 1
    pages/wizard/regions/task_step_bar.py:159:9: N802 function name should be lowercase
    pages/wizard/regions/task_step_bar.py:163:9: N802 function name should be lowercase
    pages/wizard/regions/task_step_bar.py:167:9: N802 function name should be lowercase
    pages/wizard/regions/task_step_bar.py:171:9: N802 function name should be lowercase
    pages/wizard/regions/task_step_bar.py:175:9: N802 function name should be lowercase
    pages/wizard/regions/task_step_bar.py:200:9: N806 variable in function should be lowercase
    pages/wizard/regions/task_step_bar.py:201:9: N806 variable in function should be lowercase
    pages/wizard/regions/task_step_bar.py:248:17: E711 comparison to None should be 'if cond is None:'
    pages/wizard/regions/task_step_bar.py:252:9: E303 too many blank lines (2)
    pages/wizard/regions/deployment_step_bar.py:130:9: N802 function name should be lowercase
    pages/wizard/regions/deployment_step_bar.py:134:9: N802 function name should be lowercase
    pages/wizard/regions/deployment_step_bar.py:138:9: N802 function name should be lowercase
    pages/wizard/regions/deployment_step_bar.py:142:9: N802 function name should be lowercase
    pages/wizard/regions/deployment_step_bar.py:146:9: N802 function name should be lowercase
    pages/wizard/regions/navigation_buttons.py:1:1: F401 're' imported but unused
    pages/wizard/regions/navigation_buttons.py:5:1: E302 expected 2 blank lines, found 1
    pages/wizard/regions/navigation_buttons.py:93:9: N806 variable in function should be lowercase
    pages/wizard/regions/navigation_buttons.py:102:9: N806 variable in function should be lowercase
    pages/wizard/openshift/nodes.py:4:1: E302 expected 2 blank lines, found 1
    pages/wizard/openshift/nodes.py:124:1: W391 blank line at end of file
    pages/wizard/openshift/configuration.py:4:1: E302 expected 2 blank lines, found 1
    pages/wizard/openshift/configuration.py:88:1: W391 blank line at end of file
    pages/wizard/satellite/insights.py:4:1: F401 'pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/satellite/insights.py:6:1: E302 expected 2 blank lines, found 1
    pages/wizard/satellite/insights.py:12:5: E301 expected 1 blank line, found 0
    pages/wizard/satellite/update_availability.py:29:5: E303 too many blank lines (2)
    pages/wizard/rhev/engine.py:5:1: E302 expected 2 blank lines, found 1
    pages/wizard/rhev/engine.py:29:1: W391 blank line at end of file
    pages/wizard/rhev/hosts.py:1:1: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:10:41: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hosts.py:11:13: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hosts.py:11:53: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hosts.py:12:13: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hosts.py:15:34: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hosts.py:16:13: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hosts.py:16:53: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hosts.py:17:13: E128 continuation line under-indented for visual indent                                           
    pages/wizard/rhev/hosts.py:22:29: E231 missing whitespace after ':'
    pages/wizard/rhev/hosts.py:28:5: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:47:5: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:48:5: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:112:5: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:121:5: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:146:5: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:150:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:151:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:152:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:153:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:154:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:155:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:156:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:157:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:158:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:182:70: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hosts.py:183:17: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hosts.py:201:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:206:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:207:13: E265 block comment should start with '# '
    pages/wizard/rhev/hosts.py:211:1: W391 blank line at end of file
    pages/wizard/rhev/configuration.py:4:1: E302 expected 2 blank lines, found 1
    pages/wizard/rhev/configuration.py:104:1: W391 blank line at end of file
    pages/wizard/rhev/hypervisor.py:5:1: E302 expected 2 blank lines, found 1
    pages/wizard/rhev/hypervisor.py:12:44: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hypervisor.py:13:9: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hypervisor.py:14:42: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hypervisor.py:15:9: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hypervisor.py:17:53: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hypervisor.py:18:9: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hypervisor.py:19:51: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hypervisor.py:20:9: E128 continuation line under-indented for visual indent                                                    
    pages/wizard/rhev/hypervisor.py:21:50: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hypervisor.py:22:9: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hypervisor.py:23:52: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hypervisor.py:24:9: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hypervisor.py:25:53: E502 the backslash is redundant between brackets
    pages/wizard/rhev/hypervisor.py:26:9: E128 continuation line under-indented for visual indent
    pages/wizard/rhev/hypervisor.py:28:5: E265 block comment should start with '# '
    pages/wizard/rhev/hypervisor.py:31:5: E265 block comment should start with '# '
    pages/wizard/rhev/hypervisor.py:92:5: E265 block comment should start with '# '
    pages/wizard/rhev/hypervisor.py:138:1: W391 blank line at end of file
    pages/wizard/rhev/storage.py:4:1: E302 expected 2 blank lines, found 1
    pages/wizard/rhev/storage.py:14:5: E265 block comment should start with '# '
    pages/wizard/rhev/storage.py:51:5: E265 block comment should start with '# '
    pages/wizard/rhev/storage.py:56:5: E265 block comment should start with '# '
    pages/wizard/rhev/storage.py:61:5: E265 block comment should start with '# '
    pages/wizard/rhev/storage.py:107:1: W391 blank line at end of file
    pages/wizard/rhev/setup_type.py:4:1: F401   'pages.wizard.regions.deployment_step_bar.DeploymentStepBar' imported but unused
    pages/wizard/rhev/setup_type.py:6:1: E302 expected 2 blank lines, found 1
    pages/wizard/subscriptions/review_subscriptions.py:1:1: F401 'selenium.webdriver.common.by.By'     imported but unused
    pages/regions/header_menu.py:45:17: E126 continuation line over-indented for hanging indent
