### PR TITLE
expected texts in separate file

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,8 @@ py.test to load it.
 """
 
 pytest_plugins = "plugin.selenium",\
-    "plugin.navigation"
+    "plugin.navigation",\
+    "plugin.expected_text"
 
 ####################################################################################################
 # Command line options available as fixtures for QCI tests
@@ -30,4 +31,10 @@ def pytest_addoption(parser):
         "--deployment-name",
         action="store",
         help="Name of the deployment to test",
+        default=None)
+
+    parser.addoption(
+        "--qci-expected-text",
+        action="store",
+        help="File with the expected text lines in json format",
         default=None)

--- a/plugin/expected_text.py
+++ b/plugin/expected_text.py
@@ -1,0 +1,9 @@
+import pytest
+import json
+
+@pytest.fixture
+def expected_text(request):
+    text_file = request.config.getoption("--qci-expected-text")
+    with open(text_file) as text:
+        data = json.load(text)
+    return data

--- a/pytest.ini.example
+++ b/pytest.ini.example
@@ -1,4 +1,4 @@
 [pytest]
 base_url = https:// #Set this to the URL of the fusor server under test
 sensitive_url = example\.com
-addopts = --driver Firefox --variables variables.yaml
+addopts = --driver Firefox --variables variables.yaml --qci-expected-text text.json

--- a/text.json
+++ b/text.json
@@ -1,0 +1,18 @@
+{
+    "product_selection_pg_i_icons":
+    {
+        "rhv_expected_text": "Complete enterprise virtualization management for servers and desktops on the same infrastructure",
+        "osp_expected_text": "Flexible, secure foundations to build a massively scalable private or public cloud",
+        "cfme_expected_text": "Manage your virtual, private, and hybrid cloud infrastructures",
+        "ocp_expected_text": "Develop, host, and scale applications in a cloud environment"
+    },
+    "product_selection_pg_req_box":
+    {
+        "general_expected_text": "General\nRed Hat Customer Portal username and password. This account must be an Organization Administrator within the Portal\nSufficient subscriptions to complete this deployment\nHost machines are started and discoverable\nNetworks and subsets are set up and available",
+        "rhv_expected_text": "Red Hat Virtualization\nEngine + Hypervisor\n2 hosts (1 for engine, 1 for hypervisor). Engine host requires 25 GB disk space, 4GB RAM, and 2 CPU. Hypervisor host requires 10 GB disk space, 16GB RAM, and 4 CPUs\nAll host hardware clocks are synchronized with the hardware clock on the Satellite system\nNFS/GlusterFS share. For data domain: IP address and shared path\nSelf-hosted\n1 host for hypervisor. Hypervisor host requires 70 GB disk space, 24GB RAM, and 4 CPUs\nAll host hardware clocks are synchronized with the hardware clock on the Satellite system\nNFS/GlusterFS share. For data domain, and self-hosted domain: IP address and shared path",
+        "osp_expected_text": "Red Hat OpenStack Platform\nIP address to the undercloud that was set up according to the instructions found in QuickStart Cloud Installer Installation Guide\n2 overcloud nodes (1 controller node with 100GB disk space, 32GB RAM, 4CPUs and 1 compute node with 100GB disk space, 16GB RAM, 4CPUs)\nAll node hardware clocks are synchronized with the hardware clock on the Satellite system\nRefer to the Power Management Drivers appendix in the Director Installation and Usage manual for the current list of supported power management interfaces.",
+        "cfme_expected_text": "Red Hat CloudForms\nHypervisor host requires at least an ADDITIONAL 8 GB RAM and 4 CPUs\nNFS/GlusterFS share. For export domain: IP address and shared path",
+        "ocp_expected_text": "OpenShift Enterprise by Red Hat\nRequires Red Hat Virtualization to be selected to deploy OpenShift Enterprise\nNFS/GlusterFS share for persistent storage to be used with internal OpenShift registry\nAll host hardware clocks are synchronized with the hardware clock on the Satellite system\nHypervisor host requires at least an ADDITIONAL 16 GB RAM and 4 CPUs\nData domain NFS/GlusterFS share must have at least 75 GB free space\nNote: Requirements will change depending upon OpenShift configuration of master and worker nodes",
+        "disconnected_expected_text": "Disconnected network scenario\nIf you are deploying into an environment that does not have external network access, these are additional requirements:\nURL to an alternate repository to download content from\nSubscription manifest"
+    }
+}


### PR DESCRIPTION
I've left the lines in text.json looong and ugly on purpose. To my mind, this is a copy/paste operation and since the text is in a separate file, the test code readability is not decreased.
If any of the texts we are testing changes in any way, we will have to change the text.json file.