### PR TITLE
qci98: remove print statement

### DIFF
--- a/tests/test_req_links_clickable_QCI98.py
+++ b/tests/test_req_links_clickable_QCI98.py
@@ -12,5 +12,4 @@
 def test_qci_links_clickable(new_deployment_pg, expected_text):
     links = new_deployment_pg.get_requirement_block_links()
 
-    print expected_text['req_box_links']
     assert cmp(expected_text['req_box_links'], links) == 0


### PR DESCRIPTION
In test for qci98 I forgot a print statement from my testing, I'm removing it in this PR. I'm going to merge this right now since it's a one-line removal PR.