### PR TITLE
Fix git rebase removing osp config page transition

### DIFF
--- a/lib/deployment_runner.py
+++ b/lib/deployment_runner.py
@@ -348,6 +348,8 @@ class UIDeploymentRunner(object):
         page.set_floating_ip_net_gateway(floating_ip_network_gateway)
         page.set_admin_passwords(admin_password)
 
+        return page.click_next()
+
     def ocp_nodes(self, page):
         '''
         OpenShift Master/Nodes specs


### PR DESCRIPTION
When I rebased deployment_runner during OCP webui commit it removed
'return page.click_next()' from osp_configure_overcloud() blocking the
transition to the CFME page

BLAME: Landon :(