### PR TITLE
Add a retry on exception to scroll click method

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -107,20 +107,23 @@ class Page(object):
          scroll/click until the total number of attempts equals the max number
          of attempts
         """
-        attempts = 0
-        while attempts < click_attempts_max:
-            attempts += 1
+        for attempts in xrange(0, click_attempts_max):
             if scroll:
                 self.scroll_to_element(element)
 
             try:
                 element.click()
                 break
-            except WebDriverException:
+            except WebDriverException as clickex:
                 # Raise the click exception if scrolling disabled or
                 # max number of scroll->click attempts
                 if not scroll or attempts >= click_attempts_max:
                     raise
+
+                print "Click attempt {} failed: {} - {}".format(
+                    attempts + 1,
+                    clickex.__class__.__name__,
+                    clickex)
 
     def scroll_to_element(self, element):
         """

--- a/pages/page.py
+++ b/pages/page.py
@@ -98,15 +98,29 @@ class Page(object):
 
         return not jquery_active
 
-    def click(self, element, scroll=True):
+    def click(self, element, scroll=True, click_attempts_max=2):
         """
         Click on the target element. If scroll is True, this will attempt to
-        scroll the element into view then click on it
-        """
-        if scroll:
-            self.scroll_to_element(element)
+         scroll the element into view then click on it.
 
-        element.click()
+        If the click attempt fails with WebDriverException then retry
+         scroll/click until the total number of attempts equals the max number
+         of attempts
+        """
+        attempts = 0
+        while attempts < click_attempts_max:
+            attempts += 1
+            if scroll:
+                self.scroll_to_element(element)
+
+            try:
+                element.click()
+                break
+            except WebDriverException:
+                # Raise the click exception if scrolling disabled or
+                # max number of scroll->click attempts
+                if not scroll or attempts >= click_attempts_max:
+                    raise
 
     def scroll_to_element(self, element):
         """


### PR DESCRIPTION
During a scroll->click action a WebDriverException will be registered
because the element to click is beneath another element (typically the
cancel-back-next bar).
This changed adds addtional (default:1) attempts to scroll then click on
the element when a WebDriverException occurs