### PR TITLE
Check for disabled RHV data center/cluster names

### DIFF
--- a/lib/deployment_runner.py
+++ b/lib/deployment_runner.py
@@ -118,8 +118,11 @@ class UIDeploymentRunner(object):
         # Custom data center & cluster name in RHVSH disabled for QCI 1.0
         # See https://bugzilla.redhat.com/show_bug.cgi?id=1367777
         if self.rhv.rhv_setup_type != 'selfhost':
-            page.set_data_center_name(self.rhv.data_center_name)
-            page.set_cluster_name(self.rhv.cluster_name)
+            if page.is_data_center_name_field_enabled():
+                page.set_data_center_name(self.rhv.data_center_name)
+
+            if page.is_cluster_name_field_enabled():
+                page.set_cluster_name(self.rhv.cluster_name)
 
         page.set_cpu_type(self.rhv.cpu_type)
         return page.click_next()

--- a/lib/deployment_runner.py
+++ b/lib/deployment_runner.py
@@ -117,12 +117,13 @@ class UIDeploymentRunner(object):
 
         # Custom data center & cluster name in RHVSH disabled for QCI 1.0
         # See https://bugzilla.redhat.com/show_bug.cgi?id=1367777
-        if self.rhv.rhv_setup_type != 'selfhost':
-            if page.is_data_center_name_field_enabled():
-                page.set_data_center_name(self.rhv.data_center_name)
+        # Temporarily disabled for RHV in QCI 1.1
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1413194
+        if page.is_data_center_name_field_enabled():
+            page.set_data_center_name(self.rhv.data_center_name)
 
-            if page.is_cluster_name_field_enabled():
-                page.set_cluster_name(self.rhv.cluster_name)
+        if page.is_cluster_name_field_enabled():
+            page.set_cluster_name(self.rhv.cluster_name)
 
         page.set_cpu_type(self.rhv.cpu_type)
         return page.click_next()

--- a/pages/wizard/rhv/configuration.py
+++ b/pages/wizard/rhv/configuration.py
@@ -51,6 +51,12 @@ class Configuration(QCIPage):
     def cpu_type_search_field(self):
         return self.selenium.find_element(*self._cpu_type_search_loc)
 
+    def is_data_center_name_field_enabled(self):
+        return self.data_center_name_field.is_enabled()
+
+    def is_cluster_name_field_enabled(self):
+        return self.cluster_name_field.is_enabled()
+
     def set_root_password(self, password):
         self.root_password_field.clear()
         self.root_password_field.send_keys(password)


### PR DESCRIPTION
The RHV data center & cluster name fields are throwing an exception when
attempting the clear and set the name because the fields are disabled.