### PR TITLE
Refactor configuration parsing code out of deployment_runner

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,8 @@ This file specifies fixtures that are located under the plugins directory.
 Any files added to the plugin directory will need to be listed below for
 py.test to load it.
 """
+import pytest
+from lib.deployment_config import DeploymentConfig
 
 pytest_plugins = "plugin.selenium",\
     "plugin.navigation",\
@@ -17,8 +19,6 @@ pytest_plugins = "plugin.selenium",\
 # def foo_fixture(request):
 #     return request.config.getoption("--foo-fixture")
 ####################################################################################################
-
-
 def pytest_addoption(parser):
     """
     parser.addoption(
@@ -38,3 +38,8 @@ def pytest_addoption(parser):
         action="store",
         help="File with the expected text lines in json format",
         default=None)
+
+@pytest.fixture
+def deployment_config(variables):
+    print "*** Create deployment config"
+    return DeploymentConfig(conf_dict=variables)

--- a/lib/deployment_config.py
+++ b/lib/deployment_config.py
@@ -1,0 +1,131 @@
+import yaml
+from lib.deployment_configs.rhv import RHV
+from lib.deployment_configs.satellite import Satellite
+from lib.deployment_configs.cfme import CFME
+from lib.deployment_configs.osp import OSP
+from lib.deployment_configs.ocp import OCP
+
+class DeploymentConfig(object):
+    '''
+    This class manages the configuration for a QCI deployment
+    defined by a yaml file.
+    '''
+
+    def __init__(self, path='./variables.yaml'):
+        with open(path, 'r') as conffile:
+            conf = yaml.load(conffile)
+
+        # Initialize RHV config structure:
+        self.__init_rhv(conf['deployment']['products']['rhv'])
+
+        # Initialize Satellite structure:
+        self.__init_sat(conf['deployment']['products']['sat'])
+
+        # Initialize CFME Structure
+        self.__init_cfme(conf['deployment']['products']['cfme'])
+
+        # Initialize OSP Structure
+        self.__init_osp(conf['deployment']['products']['osp'])
+
+        # Initialize OCP Structure
+        self.__init_ocp(conf['deployment']['products']['ose'])
+
+        self.products = conf['deployment']['install']
+        self.deployment_id = conf['deployment']['deployment_id']
+        self.credentials = conf['credentials']
+
+    def __init_rhv(self, conf_dict):
+        self.rhv = RHV()
+        self.rhv.cluster_name = conf_dict['cluster_name']
+        self.rhv.cpu_type = conf_dict['cpu_type']
+        self.rhv.data_center_name = conf_dict['data_center_name']
+        self.rhv.data_domain_address = conf_dict['data_domain_address']
+        self.rhv.data_domain_name = conf_dict['data_domain_name']
+        self.rhv.data_domain_share_path = conf_dict['data_domain_share_path']
+        self.rhv.export_domain_address = conf_dict['export_domain_address']
+        self.rhv.export_domain_name = conf_dict['export_domain_name']
+        self.rhv.export_domain_share_path = conf_dict['export_domain_share_path']
+        self.rhv.hypervisor_count = conf_dict['hypervisor_count']
+        self.rhv.include = conf_dict['include']
+        self.rhv.rhv_setup_type = conf_dict['rhv_setup_type']
+        self.rhv.rhvh_hostname = conf_dict['rhvh_hostname']
+        self.rhv.rhvh_macs = conf_dict['rhvh_macs']
+        self.rhv.rhvm_adminpass = conf_dict['rhvm_adminpass']
+        self.rhv.rhvm_engine = conf_dict['rhvm_engine']
+        self.rhv.rhvm_hostname = conf_dict['rhvm_hostname']
+        self.rhv.rhvm_hypervisors = conf_dict['rhvm_hypervisors']
+        self.rhv.rhvm_mac = conf_dict['rhvm_mac']
+        self.rhv.storage_type = conf_dict['storage_type']
+        self.rhv.selfhosted_domain_name = conf_dict['selfhosted_domain_name']
+        self.rhv.selfhosted_domain_address = conf_dict['selfhosted_domain_address']
+        self.rhv.selfhosted_domain_share_path = conf_dict['selfhosted_domain_share_path']
+        self.rhv.self_hosted_engine_hostname = conf_dict['self_hosted_engine_hostname']
+
+
+    def __init_sat(self, conf_dict):
+        self.sat = Satellite()
+        self.sat.deploy_org = conf_dict['deploy_org']
+        self.sat.disconnected_manifest = conf_dict['disconnected_manifest']
+        self.sat.disconnected_url = conf_dict['disconnected_url']
+        self.sat.enable_access_insights = conf_dict['enable_access_insights']
+        self.sat.env_path = conf_dict['env_path']
+        self.sat.rhsm_subs = conf_dict['rhsm_subs']
+        self.sat.sat_desc = conf_dict['sat_desc']
+        self.sat.sat_name = conf_dict['sat_name']
+        self.sat.update_lifecycle_immediately = conf_dict['update_lifecycle_immediately']
+        self.sat.create_new_env = conf_dict['create_new_env']
+        self.sat.new_env = conf_dict['new_env']
+        self.sat.use_default_org_view = conf_dict['use_default_org_view']
+        self.sat.disconnected_mode = conf_dict['disconnected_mode']
+        self.sat.rhsm_satellite = conf_dict['rhsm_satellite']
+
+
+    def __init_cfme(self, conf_dict):
+        self.cfme = CFME()
+        self.cfme.cfme_address = conf_dict['cfme_address']
+        self.cfme.cfme_admin_password = conf_dict['cfme_admin_password']
+        self.cfme.cfme_install_loc = conf_dict['cfme_install_loc']
+        self.cfme.cfme_root_password = conf_dict['cfme_root_password']
+        self.cfme.cfme_db_password = conf_dict['cfme_db_password']
+
+    def __init_osp(self, conf_dict):
+        self.osp = OSP()
+        self.osp.compute_count = conf_dict['compute_count']
+        self.osp.controller_count = conf_dict['controller_count']
+        self.osp.block_storage_count = conf_dict['block_storage_count']
+        self.osp.object_storage_count = conf_dict['object_storage_count']
+        self.osp.director_address = conf_dict['director_address']
+        self.osp.director_ui_url = conf_dict['director_ui_url']
+        self.osp.director_vm_name = conf_dict['director_vm_name']
+        self.osp.overcloud_nodes = conf_dict['overcloud_nodes']
+        self.osp.undercloud_address = conf_dict['undercloud_address']
+        self.osp.undercloud_pass = conf_dict['undercloud_pass']
+        self.osp.undercloud_user = conf_dict['undercloud_user']
+        self.osp.network = conf_dict['network']
+
+    def __init_ocp(self, conf_dict):
+        self.ocp = OCP()
+        self.ocp.ose_address = conf_dict['ose_address']
+        self.ocp.subscription = conf_dict['subscription']
+        self.ocp.install_loc = conf_dict['install_loc']
+        self.ocp.storage_size = conf_dict['storage_size']
+        self.ocp.username = conf_dict['username']
+        self.ocp.user_password = conf_dict['user_password']
+        self.ocp.root_password = conf_dict['root_password']
+        self.ocp.master_vcpu = conf_dict['master_vcpu']
+        self.ocp.master_ram = conf_dict['master_ram']
+        self.ocp.master_disk = conf_dict['master_disk']
+        self.ocp.node_vcpu = conf_dict['node_vcpu']
+        self.ocp.node_ram = conf_dict['node_ram']
+        self.ocp.node_disk = conf_dict['node_disk']
+        self.ocp.available_vcpu = conf_dict['available_vcpu']
+        self.ocp.available_ram = conf_dict['available_ram']
+        self.ocp.available_disk = conf_dict['available_disk']
+        self.ocp.number_master_nodes = conf_dict['number_master_nodes']
+        self.ocp.number_worker_nodes = conf_dict['number_worker_nodes']
+        self.ocp.storage_type = conf_dict['storage_type']
+        self.ocp.storage_name = conf_dict['storage_name']
+        self.ocp.storage_host = conf_dict['storage_host']
+        self.ocp.export_path = conf_dict['export_path']
+        self.ocp.subdomain_name = conf_dict['subdomain_name']
+        self.ocp.sample_apps = conf_dict['sample_apps']

--- a/lib/deployment_config.py
+++ b/lib/deployment_config.py
@@ -34,6 +34,7 @@ class DeploymentConfig(object):
         self.products = conf_dict['deployment']['install']
         self.deployment_id = conf_dict['deployment']['deployment_id']
         self.credentials = conf_dict['credentials']
+        self.deployment_timeout = conf_dict['deployment']['deployment_timeout']
 
     def __init_rhv(self, conf_dict):
         self.rhv = RHV()
@@ -130,3 +131,79 @@ class DeploymentConfig(object):
         self.ocp.export_path = conf_dict['export_path']
         self.ocp.subdomain_name = conf_dict['subdomain_name']
         self.ocp.sample_apps = conf_dict['sample_apps']
+
+    ##############
+    # Properties #
+    ##############
+    @property
+    def credentials(self):
+        return self.__credentials
+
+    @credentials.setter
+    def credentials(self, value):
+        self.__credentials = value
+
+    @property
+    def cfme(self):
+        return self.__cfme
+
+    @cfme.setter
+    def cfme(self, value):
+        self.__cfme = value
+
+    @property
+    def deployment_id(self):
+        return self.__deployment_id
+
+    @deployment_id.setter
+    def deployment_id(self, value):
+        self.__deployment_id = value
+
+    @property
+    def deployment_timeout(self):
+        return self.__deployment_timeout
+
+    @deployment_timeout.setter
+    def deployment_timeout(self, value):
+        self.__deployment_timeout = value
+
+    @property
+    def ocp(self):
+        return self.__ocp
+
+    @ocp.setter
+    def ocp(self, value):
+        self.__ocp = value
+
+    @property
+    def osp(self):
+        return self.__osp
+
+    @osp.setter
+    def osp(self, value):
+        self.__osp = value
+
+    @property
+    def products(self):
+        return self.__products
+
+    @products.setter
+    def products(self, value):
+        self.__products = value
+
+    @property
+    def rhv(self):
+        return self.__rhv
+
+    @rhv.setter
+    def rhv(self, value):
+        self.__rhv = value
+
+    @property
+    def sat(self):
+        return self.__sat
+
+    @sat.setter
+    def sat(self, value):
+        self.__sat = value
+

--- a/lib/deployment_config.py
+++ b/lib/deployment_config.py
@@ -11,28 +11,29 @@ class DeploymentConfig(object):
     defined by a yaml file.
     '''
 
-    def __init__(self, path='./variables.yaml'):
-        with open(path, 'r') as conffile:
-            conf = yaml.load(conffile)
+    def __init__(self, conf_dict=None, path='./variables.yaml'):
+        if conf_dict is None:
+            with open(path, 'r') as conffile:
+                conf_dict = yaml.load(conffile)
 
         # Initialize RHV config structure:
-        self.__init_rhv(conf['deployment']['products']['rhv'])
+        self.__init_rhv(conf_dict['deployment']['products']['rhv'])
 
         # Initialize Satellite structure:
-        self.__init_sat(conf['deployment']['products']['sat'])
+        self.__init_sat(conf_dict['deployment']['products']['sat'])
 
         # Initialize CFME Structure
-        self.__init_cfme(conf['deployment']['products']['cfme'])
+        self.__init_cfme(conf_dict['deployment']['products']['cfme'])
 
         # Initialize OSP Structure
-        self.__init_osp(conf['deployment']['products']['osp'])
+        self.__init_osp(conf_dict['deployment']['products']['osp'])
 
         # Initialize OCP Structure
-        self.__init_ocp(conf['deployment']['products']['ose'])
+        self.__init_ocp(conf_dict['deployment']['products']['ose'])
 
-        self.products = conf['deployment']['install']
-        self.deployment_id = conf['deployment']['deployment_id']
-        self.credentials = conf['credentials']
+        self.products = conf_dict['deployment']['install']
+        self.deployment_id = conf_dict['deployment']['deployment_id']
+        self.credentials = conf_dict['credentials']
 
     def __init_rhv(self, conf_dict):
         self.rhv = RHV()

--- a/lib/deployment_configs/cfme.py
+++ b/lib/deployment_configs/cfme.py
@@ -1,4 +1,4 @@
-class Cfme(object):
+class CFME(object):
     '''
     This class contains all the config information for a CFME
     deployment.
@@ -42,6 +42,5 @@ class Cfme(object):
 
     @cfme_db_password.setter
     def cfme_db_password(self, value):
-        print "set it"
         self.__cfme_db_password = value
 

--- a/lib/deployment_configs/cfme.py
+++ b/lib/deployment_configs/cfme.py
@@ -1,0 +1,47 @@
+class Cfme(object):
+    '''
+    This class contains all the config information for a CFME
+    deployment.
+    '''
+
+    @property
+    def cfme_address(self):
+        return self.__cfme_address
+
+    @cfme_address.setter
+    def cfme_address(self, value):
+        self.__cfme_address = value
+
+    @property
+    def cfme_admin_password(self):
+        return self.__cfme_admin_password
+
+    @cfme_admin_password.setter
+    def cfme_admin_password(self, value):
+        self.__cfme_admin_password = value
+
+    @property
+    def cfme_install_loc(self):
+        return self.__cfme_install_loc
+
+    @cfme_install_loc.setter
+    def cfme_install_loc(self, value):
+        self.__cfme_install_loc = value
+
+    @property
+    def cfme_root_password(self):
+        return self.__cfme_root_password
+
+    @cfme_root_password.setter
+    def cfme_root_password(self, value):
+        self.__cfme_root_password = value
+
+    @property
+    def cfme_db_password(self):
+        return self.__cfme_db_password
+
+    @cfme_db_password.setter
+    def cfme_db_password(self, value):
+        print "set it"
+        self.__cfme_db_password = value
+

--- a/lib/deployment_configs/ocp.py
+++ b/lib/deployment_configs/ocp.py
@@ -1,0 +1,196 @@
+class OCP(object):
+    '''
+    This class contains all the config information for an OCP
+    deployment.
+    '''
+    @property
+    def ose_address(self):
+        return self.__ose_address
+
+    @ose_address.setter
+    def ose_address(self, value):
+        self.__ose_address = value
+
+    @property
+    def subscription(self):
+        return self.__subscription
+
+    @subscription.setter
+    def subscription(self, value):
+        self.__subscription = value
+
+    @property
+    def install_loc(self):
+        return self.__install_loc
+
+    @install_loc.setter
+    def install_loc(self, value):
+        self.__install_loc = value
+
+    @property
+    def storage_size(self):
+        return self.__storage_size
+
+    @storage_size.setter
+    def storage_size(self, value):
+        self.__storage_size = value
+
+    @property
+    def username(self):
+        return self.__username
+
+    @username.setter
+    def username(self, value):
+        self.__username = value
+
+    @property
+    def user_password(self):
+        return self.__user_password
+
+    @user_password.setter
+    def user_password(self, value):
+        self.__user_password = value
+
+    @property
+    def root_password(self):
+        return self.__root_password
+
+    @root_password.setter
+    def root_password(self, value):
+        self.__root_password = value
+
+    @property
+    def master_vcpu(self):
+        return self.__master_vcpu
+
+    @master_vcpu.setter
+    def master_vcpu(self, value):
+        self.__master_vcpu = value
+
+    @property
+    def master_ram(self):
+        return self.__master_ram
+
+    @master_ram.setter
+    def master_ram(self, value):
+        self.__master_ram = value
+
+    @property
+    def master_disk(self):
+        return self.__master_disk
+
+    @master_disk.setter
+    def master_disk(self, value):
+        self.__master_disk = value
+
+    @property
+    def node_vcpu(self):
+        return self.__node_vcpu
+
+    @node_vcpu.setter
+    def node_vcpu(self, value):
+        self.__node_vcpu = value
+
+    @property
+    def node_ram(self):
+        return self.__node_ram
+
+    @node_ram.setter
+    def node_ram(self, value):
+        self.__node_ram = value
+
+    @property
+    def node_disk(self):
+        return self.__node_disk
+
+    @node_disk.setter
+    def node_disk(self, value):
+        self.__node_disk = value
+
+    @property
+    def available_vcpu(self):
+        return self.__available_vcpu
+
+    @available_vcpu.setter
+    def available_vcpu(self, value):
+        self.__available_vcpu = value
+
+    @property
+    def available_ram(self):
+        return self.__available_ram
+
+    @available_ram.setter
+    def available_ram(self, value):
+        self.__available_ram = value
+
+    @property
+    def available_disk(self):
+        return self.__available_disk
+
+    @available_disk.setter
+    def available_disk(self, value):
+        self.__available_disk = value
+
+    @property
+    def number_master_nodes(self):
+        return self.__number_master_nodes
+
+    @number_master_nodes.setter
+    def number_master_nodes(self, value):
+        self.__number_master_nodes = value
+
+    @property
+    def number_worker_nodes(self):
+        return self.__number_worker_nodes
+
+    @number_worker_nodes.setter
+    def number_worker_nodes(self, value):
+        self.__number_worker_nodes = value
+
+    @property
+    def storage_type(self):
+        return self.__storage_type
+
+    @storage_type.setter
+    def storage_type(self, value):
+        self.__storage_type = value
+
+    @property
+    def storage_name(self):
+        return self.__storage_name
+
+    @storage_name.setter
+    def storage_name(self, value):
+        self.__storage_name = value
+
+    @property
+    def storage_host(self):
+        return self.__storage_host
+
+    @storage_host.setter
+    def storage_host(self, value):
+        self.__storage_host = value
+
+    @property
+    def export_path(self):
+        return self.__export_path
+
+    @export_path.setter
+    def export_path(self, value):
+        self.__export_path = value
+
+    @property
+    def subdomain_name(self):
+        return self.__subdomain_name
+
+    @subdomain_name.setter
+    def subdomain_name(self, value):
+        self.__subdomain_name = value
+
+    @property
+    def sample_apps(self):
+        return self.__sample_apps
+
+    @sample_apps.setter
+    def sample_apps(self, value):
+        self.__sample_apps = value

--- a/lib/deployment_configs/osp.py
+++ b/lib/deployment_configs/osp.py
@@ -1,0 +1,103 @@
+class OSP(object):
+    '''
+    This class contains all the config information for an OSP
+    deployment.
+    '''
+
+    @property
+    def compute_count(self):
+        return self.__compute_count
+
+    @compute_count.setter
+    def compute_count(self, value):
+        self.__compute_count = value
+
+    @property
+    def controller_count(self):
+        return self.__controller_count
+
+    @controller_count.setter
+    def controller_count(self, value):
+        self.__controller_count = value
+
+    @property
+    def block_storage_count(self):
+        return self.__block_storage_count
+
+    @block_storage_count.setter
+    def block_storage_count(self, value):
+        self.__block_storage_count = value
+
+    @property
+    def object_storage_count(self):
+        return self.__object_storage_count
+
+    @object_storage_count.setter
+    def object_storage_count(self, value):
+        self.__object_storage_count = value
+
+    @property
+    def director_address(self):
+        return self.__director_address
+
+    @director_address.setter
+    def director_address(self, value):
+        self.__director_address = value
+
+    @property
+    def director_ui_url(self):
+        return self.__director_ui_url
+
+    @director_ui_url.setter
+    def director_ui_url(self, value):
+        self.__director_ui_url = value
+
+    @property
+    def director_vm_name(self):
+        return self.__director_vm_name
+
+    @director_vm_name.setter
+    def director_vm_name(self, value):
+        self.__director_vm_name = value
+
+    # TODO:  Need to make over cloud node structure
+    @property
+    def overcloud_nodes(self):
+        return self.__overcloud_nodes
+
+    @overcloud_nodes.setter
+    def overcloud_nodes(self, value):
+        self.__overcloud_nodes = value
+
+    @property
+    def undercloud_address(self):
+        return self.__undercloud_address
+
+    @undercloud_address.setter
+    def undercloud_address(self, value):
+        self.__undercloud_address = value
+
+    @property
+    def undercloud_pass(self):
+        return self.__undercloud_pass
+
+    @undercloud_pass.setter
+    def undercloud_pass(self, value):
+        self.__undercloud_pass = value
+
+    @property
+    def undercloud_user(self):
+        return self.__undercloud_user
+
+    @undercloud_user.setter
+    def undercloud_user(self, value):
+        self.__undercloud_user = value
+
+    # TODO:  Need to make network structure.
+    @property
+    def network(self):
+        return self.__network
+
+    @network.setter
+    def network(self, value):
+        self.__network = value

--- a/lib/deployment_configs/rhv.py
+++ b/lib/deployment_configs/rhv.py
@@ -1,4 +1,4 @@
-class Rhv(object):
+class RHV(object):
     '''
     This class contains all the config information for a RHV
     deployment.

--- a/lib/deployment_configs/rhv.py
+++ b/lib/deployment_configs/rhv.py
@@ -1,0 +1,197 @@
+class Rhv(object):
+    '''
+    This class contains all the config information for a RHV
+    deployment.
+    '''
+
+    @property
+    def cluster_name(self):
+        return self.__cluster_name
+
+    @cluster_name.setter
+    def cluster_name(self, value):
+        self.__cluster_name = value
+
+    @property
+    def cpu_type(self):
+        return self.__cpu_type
+
+    @cpu_type.setter
+    def cpu_type(self, value):
+        self.__cpu_type = value
+
+    @property
+    def data_center_name(self):
+        return self.__data_center_name
+
+    @data_center_name.setter
+    def data_center_name(self, value):
+        self.__data_center_name = value
+
+    @property
+    def data_domain_address(self):
+        return self.__data_domain_address
+
+    @data_domain_address.setter
+    def data_domain_address(self, value):
+        self.__data_domain_address = value
+
+    @property
+    def data_domain_name(self):
+        return self.__data_domain_name
+
+    @data_domain_name.setter
+    def data_domain_name(self, value):
+        self.__data_domain_name = value
+
+    @property
+    def data_domain_share_path(self):
+        return self.__data_domain_share_path
+
+    @data_domain_share_path.setter
+    def data_domain_share_path(self, value):
+        self.__data_domain_share_path = value
+
+    @property
+    def export_domain_address(self):
+        return self.__export_domain_address
+
+    @export_domain_address.setter
+    def export_domain_address(self, value):
+        self.__export_domain_address = value
+
+    @property
+    def export_domain_name(self):
+        return self.__export_domain_name
+
+    @export_domain_name.setter
+    def export_domain_name(self, value):
+        self.__export_domain_name = value
+
+    @property
+    def export_domain_share_path(self):
+        return self.__export_domain_share_path
+
+    @export_domain_share_path.setter
+    def export_domain_share_path(self, value):
+        self.__export_domain_share_path = value
+
+    @property
+    def hypervisor_count(self):
+        return self.__hypervisor_count
+
+    @hypervisor_count.setter
+    def hypervisor_count(self, value):
+        self.__hypervisor_count = value
+
+    @property
+    def include(self):
+        return self.__include
+
+    @include.setter
+    def include(self, value):
+        self.__include = value
+
+    @property
+    def rhv_setup_type(self):
+        return self.__rhv_setup_type
+
+    @rhv_setup_type.setter
+    def rhv_setup_type(self, value):
+        self.__rhv_setup_type = value
+
+    @property
+    def rhvh_hostname(self):
+        return self.__rhvh_hostname
+
+    @rhvh_hostname.setter
+    def rhvh_hostname(self, value):
+        self.__rhvh_hostname = value
+
+    @property
+    def rhvh_macs(self):
+        return self.__rhvh_macs
+
+    @rhvh_macs.setter
+    def rhvh_macs(self, value):
+        self.__rhvh_macs = value
+
+    @property
+    def rhvm_adminpass(self):
+        return self.__rhvm_adminpass
+
+    @rhvm_adminpass.setter
+    def rhvm_adminpass(self, value):
+        self.__rhvm_adminpass = value
+
+    @property
+    def rhvm_engine(self):
+        return self.__rhvm_engine
+
+    @rhvm_engine.setter
+    def rhvm_engine(self, value):
+        self.__rhvm_engine = value
+
+    @property
+    def rhvm_hostname(self):
+        return self.__rhvm_hostname
+
+    @rhvm_hostname.setter
+    def rhvm_hostname(self, value):
+        self.__rhvm_hostname = value
+
+    @property
+    def rhvm_hypervisors(self):
+        return self.__rhvm_hypervisors
+
+    @rhvm_hypervisors.setter
+    def rhvm_hypervisors(self, value):
+        self.__rhvm_hypervisors = value
+
+    @property
+    def rhvm_mac(self):
+        return self.__rhvm_mac
+
+    @rhvm_mac.setter
+    def rhvm_mac(self, value):
+        self.__rhvm_mac = value
+
+    @property
+    def storage_type(self):
+        return self.__storage_type
+
+    @storage_type.setter
+    def storage_type(self, value):
+        self.__storage_type = value
+
+    @property
+    def selfhosted_domain_name(self):
+        return self.__selfhosted_domain_name
+
+    @selfhosted_domain_name.setter
+    def selfhosted_domain_name(self, value):
+        self.__selfhosted_domain_name = value
+
+    @property
+    def selfhosted_domain_address(self):
+        return self.__selfhosted_domain_address
+
+    @selfhosted_domain_address.setter
+    def selfhosted_domain_address(self, value):
+        self.__selfhosted_domain_address = value
+
+    @property
+    def selfhosted_domain_share_path(self):
+        return self.__selfhosted_domain_share_path
+
+    @selfhosted_domain_share_path.setter
+    def selfhosted_domain_share_path(self, value):
+        self.__selfhosted_domain_share_path = value
+
+    @property
+    def self_hosted_engine_hostname(self):
+        return self.__self_hosted_engine_hostname
+
+    @self_hosted_engine_hostname.setter
+    def self_hosted_engine_hostname(self, value):
+        self.__self_hosted_engine_hostname = value

--- a/lib/deployment_configs/sat.py
+++ b/lib/deployment_configs/sat.py
@@ -1,0 +1,117 @@
+class Sat(object):
+    '''
+    This class contains all the satellite config information for a
+    deployment.
+    '''
+
+    @property
+    def deploy_org(self):
+        return self.__deploy_org
+
+    @deploy_org.setter
+    def deploy_org(self, value):
+        self.__deploy_org = value
+
+    @property
+    def disconnected_manifest(self):
+        return self.__disconnected_manifest
+
+    @disconnected_manifest.setter
+    def disconnected_manifest(self, value):
+        self.__disconnected_manifest = value
+
+    @property
+    def disconnected_url(self):
+        return self.__disconnected_url
+
+    @disconnected_url.setter
+    def disconnected_url(self, value):
+        self.__disconnected_url = value
+
+    @property
+    def enable_access_insights(self):
+        return self.__enable_access_insights
+
+    @enable_access_insights.setter
+    def enable_access_insights(self, value):
+        self.__enable_access_insights = value
+
+    @property
+    def env_path(self):
+        return self.__env_path
+
+    @env_path.setter
+    def env_path(self, value):
+        self.__env_path = value
+
+    @property
+    def use_default_org_view(self):
+        return self.__use_default_org_view
+
+    @use_default_org_view.setter
+    def use_default_org_view(self, value):
+        self.__use_default_org_view = value
+
+    @property
+    def disconnected_mode(self):
+        return self.__disconnected_mode
+
+    @disconnected_mode.setter
+    def disconnected_mode(self, value):
+        self.__disconnected_mode = value
+
+    @property
+    def sat_desc(self):
+        return self.__sat_desc
+
+    @sat_desc.setter
+    def sat_desc(self, value):
+        self.__sat_desc = value
+
+    @property
+    def sat_name(self):
+        return self.__sat_name
+
+    @sat_name.setter
+    def sat_name(self, value):
+        self.__sat_name = value
+
+    @property
+    def update_lifecycle_immediately(self):
+        return self.__update_lifecycle_immediately
+
+    @update_lifecycle_immediately.setter
+    def update_lifecycle_immediately(self, value):
+        self.__update_lifecycle_immediately = value
+
+    @property
+    def create_new_env(self):
+        return self.__create_new_env
+
+    @create_new_env.setter
+    def create_new_env(self, value):
+        self.__create_new_env = value
+
+    @property
+    def rhsm_satellite(self):
+        return self.__rhsm_satellite
+
+    @rhsm_satellite.setter
+    def rhsm_satellite(self, value):
+        self.__rhsm_satellite = value
+
+    @property
+    def rhsm_subs(self):
+        return self.__rhsm_subs
+
+    @rhsm_subs.setter
+    def rhsm_subs(self, value):
+        self.__rhsm_subs = value
+
+    @property
+    def new_env(self):
+        return self.__new_env
+
+    @new_env.setter
+    def new_env(self, value):
+        self.__new_env = value

--- a/lib/deployment_configs/satellite.py
+++ b/lib/deployment_configs/satellite.py
@@ -1,4 +1,4 @@
-class Sat(object):
+class Satellite(object):
     '''
     This class contains all the satellite config information for a
     deployment.

--- a/lib/deployment_runner.py
+++ b/lib/deployment_runner.py
@@ -14,15 +14,6 @@ class UnknownDriverTypeError(Exception):
         return "Unknown driver type: '{}'".format(self.name)
 
 
-class ProductConfig(object):
-    '''
-    A simple mapping of dictionary keys to instance attributes
-    '''
-    def __init__(self, dictionary):
-        for k, v in dictionary.items():
-            setattr(self, k, v)
-
-
 class UIDeploymentRunner(object):
     '''
     This class manages the configuration and workflow for a QCI deployment

--- a/lib/deployment_runner.py
+++ b/lib/deployment_runner.py
@@ -29,19 +29,99 @@ class UIDeploymentRunner(object):
     defined by a yaml file.
     '''
 
-    def __init__(self, path='./variables.yaml'):
-        with open(path, 'r') as conffile:
-            self.conf = yaml.load(conffile)
-        self.rhv = ProductConfig(self.conf['deployment']['products']['rhv'])
-        self.sat = ProductConfig(self.conf['deployment']['products']['sat'])
-        self.cfme = ProductConfig(self.conf['deployment']['products']['cfme'])
-        self.osp = ProductConfig(self.conf['deployment']['products']['osp'])
-        self.ocp = ProductConfig(self.conf['deployment']['products']['ose'])
+    def __init__(self, deployment_config=None):
+        if deployment_config is not None:
+            self.__init_from_deployment_config(deployment_config)
 
-        self.products = self.conf['deployment']['install']
-        self.deployment_id = self.conf['deployment']['deployment_id']
-        self.password = self.conf['credentials']['fusor']['password']
+    def __init_from_deployment_config(self, config):
+        self.deployment_id = config.deployment_id
+        self.products = config.products
+        self.credentials = config.credentials
+        self.password = config.credentials['fusor']['password']
+        self.rhv = config.rhv
+        self.sat = config.sat
+        self.cfme = config.cfme
+        self.osp = config.osp
+        self.ocp = config.ocp
 
+    ##############
+    # Attributes #
+    ##############
+    @property
+    def credentials(self):
+        return self.__credentials
+
+    @credentials.setter
+    def credentials(self, value):
+        self.__credentials = value
+
+    @property
+    def deployment_id(self):
+        return self.__deployment_id
+
+    @deployment_id.setter
+    def deployment_id(self, value):
+        self.__deployment_id = value
+
+    @property
+    def products(self):
+        return self.__products
+
+    @products.setter
+    def products(self, value):
+        self.__products = value
+
+    @property
+    def password(self):
+        return self.__password
+
+    @password.setter
+    def password(self, value):
+        self.__password = value
+
+    @property
+    def rhv(self):
+        return self.__rhv
+
+    @rhv.setter
+    def rhv(self, value):
+        self.__rhv = value
+
+    @property
+    def sat(self):
+        return self.__sat
+
+    @sat.setter
+    def sat(self, value):
+        self.__sat = value
+
+    @property
+    def cfme(self):
+        return self.__cfme
+
+    @cfme.setter
+    def cfme(self, value):
+        self.__cfme = value
+
+    @property
+    def osp(self):
+        return self.__osp
+
+    @osp.setter
+    def osp(self, value):
+        self.__osp = value
+
+    @property
+    def ocp(self):
+        return self.__ocp
+
+    @ocp.setter
+    def ocp(self, value):
+        self.__ocp = value
+
+    ###############
+    # Run Methods #
+    ###############
     def product_selection(self, page):
         '''SelectProductsPage'''
         page.select_products(self.products)
@@ -440,8 +520,8 @@ class UIDeploymentRunner(object):
         '''Content Provider Page'''
         if not self.sat.disconnected_mode:
             page.click_redhat_cdn()
-            page.set_username(self.conf['credentials']['cdn']['username'])
-            page.set_password(self.conf['credentials']['cdn']['password'])
+            page.set_username(self.credentials['cdn']['username'])
+            page.set_password(self.credentials['cdn']['password'])
         else:
             page.click_disconnected()
             page.set_disconnected_url_field(self.sat.disconnected_url)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,4 +1,5 @@
 from time import sleep
+from lib.deployment_config import DeploymentConfig
 from lib.deployment_runner import UIDeploymentRunner
 from pages.wizard.rhv.setup_type import SetupType
 from pages.wizard.rhv.engine import Engine
@@ -19,7 +20,12 @@ def test_e2e_deployment(new_deployment_pg, variables):
     actions performed on each page and the yaml values that direct those
     actions are handled by the UIDeploymentRunner class.
     '''
-    runner = UIDeploymentRunner()
+
+    # First parse the config and instantiate the deployment runner
+    config = DeploymentConfig()
+    runner = UIDeploymentRunner(deployment_config=config)
+
+    # Now navigate through the initial satellite pages
     deployment_name_pg = runner.product_selection(new_deployment_pg)
     update_avail_pg = runner.deployment_name(deployment_name_pg)
     insights_pg = runner.update_availability(update_avail_pg)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,5 +1,4 @@
 from time import sleep
-from lib.deployment_config import DeploymentConfig
 from lib.deployment_runner import UIDeploymentRunner
 from pages.wizard.rhv.setup_type import SetupType
 from pages.wizard.rhv.engine import Engine
@@ -10,8 +9,7 @@ from pages.wizard.subscriptions.review_subscriptions import ReviewSubscriptions
 from pages.wizard.review.installation_progress import InstallationProgress
 from pages.wizard.openshift.nodes import Nodes
 
-
-def test_e2e_deployment(new_deployment_pg, variables):
+def test_e2e_deployment(new_deployment_pg, deployment_config):
     '''
     Using values from the provided variables file to run a QCI deployment
 
@@ -21,16 +19,17 @@ def test_e2e_deployment(new_deployment_pg, variables):
     actions are handled by the UIDeploymentRunner class.
     '''
 
-    # First parse the config and instantiate the deployment runner
-    config = DeploymentConfig()
-    runner = UIDeploymentRunner(deployment_config=config)
+    # Create some convenience variables from the config:
+    deployment_time_max = deployment_config.deployment_timeout
+
+    # instantiate the deployment runner
+    runner = UIDeploymentRunner(deployment_config=deployment_config)
 
     # Now navigate through the initial satellite pages
     deployment_name_pg = runner.product_selection(new_deployment_pg)
     update_avail_pg = runner.deployment_name(deployment_name_pg)
     insights_pg = runner.update_availability(update_avail_pg)
     next_pg = runner.access_insights(insights_pg)
-    deployment_time_max = variables['deployment'].get('deployment_timeout', 240)
 
     # Number of retry attempts if there is failure to mount the rhv storage domains
     rhv_storage_fail_retry_max = 3

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,9 +1,9 @@
 from pages.login import LoginPage
 
 
-def test_login_admin(base_url, selenium, variables):
+def test_login_admin(base_url, selenium, deployment_config):
     login_pg = LoginPage(base_url, selenium)
     login_pg.open()
-    dashboard_pg = login_pg.login(variables['credentials']['fusor']['username'],
-                                  variables['credentials']['fusor']['password'])
+    dashboard_pg = login_pg.login(deployment_config.credentials['fusor']['username'],
+                                  deployment_config.credentials['fusor']['password'])
     assert dashboard_pg.is_the_current_page

--- a/tests/test_new_env_path_validation_QCI131.py
+++ b/tests/test_new_env_path_validation_QCI131.py
@@ -8,8 +8,8 @@
 
 from lib.deployment_runner import UIDeploymentRunner
 
-def test_new_env_path_validation(new_deployment_pg):
-    runner = UIDeploymentRunner()
+def test_new_env_path_validation(new_deployment_pg, deployment_config):
+    runner = UIDeploymentRunner(deployment_config=deployment_config)
     deployment_name_pg = runner.product_selection(new_deployment_pg)
     update_availability_pg = runner.deployment_name(deployment_name_pg)
 


### PR DESCRIPTION
The goal is to get it so the deployment runner can be used with out a YAML file.   Additionally, the approach taken will ensure that a misspelled config item will cause an error at parse time.

Essentially, there is one highlevel parser, deployment_config, and then it use various deployment config classes to support the sections of the config.   Presently no validation is occurring, but the way this has been done validation can occur very easily.